### PR TITLE
Update application.yml

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,3 +10,7 @@ spring:
   h2:
     console:
       enabled: true
+springfox:
+  documentation:
+    swagger-ui:
+      base-url: docs


### PR DESCRIPTION
 adding path for swagger-ui, now api documentation will be accessible via http://localhost:8080/docs/swagger-ui/index.html